### PR TITLE
Update READMEs for http examples.

### DIFF
--- a/examples/http-client/README.md
+++ b/examples/http-client/README.md
@@ -6,7 +6,7 @@ To run this example, switch to the `example/http-client` folder, build and run.
 
 ```sh
 $ cd examples/http-client
-$ lake build-bin
+$ lake build
 $ ./build/bin/http-client
 ```
 

--- a/examples/http-server/README.md
+++ b/examples/http-server/README.md
@@ -6,7 +6,7 @@ To run this example, switch to the `example/http-server` folder, build and run.
 
 ```sh
 $ cd examples/http-server
-$ lake build-bin
+$ lake build
 $ ./build/bin/http-server
 ```
 


### PR DESCRIPTION
Change `lake build-bin` -> `lake build` to reflect new `build` CLI for
lake. See `leanprover/lake@91ddefcf6520d04a9c463d49f617468c0d93776a`.